### PR TITLE
Target .NET 9.0 and manage NuGet packages centrally

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Overwrite csc problem matcher
         run: echo "::add-matcher::.github/csc.json"
 
-      - run: dotnet restore
+      - run: dotnet build
 
       - name: Print dotnet format version
         run: dotnet format --version

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,17 @@
+<Project>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageVersion Include="coverlet.collector" Version="6.0.2"/>
+        <PackageVersion Include="Docker.DotNet" Version="3.125.15" />
+        <PackageVersion Include="FluentFTP" Version="50.1.0" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+        <PackageVersion Include="Moq" Version="4.20.70" />
+        <PackageVersion Include="NetCoreServer" Version="8.0.7" />
+        <PackageVersion Include="xunit" Version="2.9.2"/>
+        <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2"/>
+    </ItemGroup>
+</Project>

--- a/RyuSocks.Generator/RyuSocks.Generator.csproj
+++ b/RyuSocks.Generator/RyuSocks.Generator.csproj
@@ -12,7 +12,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
     </ItemGroup>
 </Project>

--- a/RyuSocks.Test.Integration/RyuSocks.Test.Integration.csproj
+++ b/RyuSocks.Test.Integration/RyuSocks.Test.Integration.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>

--- a/RyuSocks.Test.Integration/RyuSocks.Test.Integration.csproj
+++ b/RyuSocks.Test.Integration/RyuSocks.Test.Integration.csproj
@@ -8,15 +8,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Docker.DotNet" Version="3.125.15" />
-        <PackageReference Include="FluentFTP" Version="50.1.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-        <PackageReference Include="xunit" Version="2.9.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+        <PackageReference Include="Docker.DotNet" />
+        <PackageReference Include="FluentFTP" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.2">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/RyuSocks.Test/Auth/NoAuthTests.cs
+++ b/RyuSocks.Test/Auth/NoAuthTests.cs
@@ -65,11 +65,7 @@ namespace RyuSocks.Test.Auth
             bool authDone = noAuth.Authenticate(incomingPacket, out ReadOnlySpan<byte> outgoingPacket);
 
             Assert.True(authDone);
-            // FIXME: Unable to use Assert.Null() for some reason.
-            if (outgoingPacket != null)
-            {
-                Assert.Fail($"{nameof(outgoingPacket)} is not null.");
-            }
+            Assert.True(outgoingPacket.IsEmpty);
         }
 
         [Fact]

--- a/RyuSocks.Test/RyuSocks.Test.csproj
+++ b/RyuSocks.Test/RyuSocks.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
     </PropertyGroup>

--- a/RyuSocks.Test/RyuSocks.Test.csproj
+++ b/RyuSocks.Test/RyuSocks.Test.csproj
@@ -11,14 +11,14 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-        <PackageReference Include="Moq" Version="4.20.70" />
-        <PackageReference Include="xunit" Version="2.9.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.2">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Moq" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/RyuSocks.Test/Utils/StringDataAttribute.cs
+++ b/RyuSocks.Test/Utils/StringDataAttribute.cs
@@ -118,7 +118,7 @@ namespace RyuSocks.Test.Utils
                 }
             }
 
-            return data.ToArray();
+            return [.. data];
         }
     }
 }

--- a/RyuSocks/Auth/IProxyAuth.cs
+++ b/RyuSocks/Auth/IProxyAuth.cs
@@ -25,8 +25,8 @@ namespace RyuSocks.Auth
         /// <summary>
         /// Authenticate the current session using a method-specific sub-negotiation.
         /// </summary>
-        /// <param name="incomingPacket">The incoming packet from the server/client. Could be null.</param>
-        /// <param name="outgoingPacket">The outgoing packet for the server/client. Could be null.</param>
+        /// <param name="incomingPacket">The incoming packet from the server/client. Could be empty.</param>
+        /// <param name="outgoingPacket">The outgoing packet for the server/client. Could be empty.</param>
         /// <returns>Whether the sub-negotiation to authenticate the current session is completed.</returns>
         /// <exception cref="AuthenticationException">Authentication failed.</exception>
         public bool Authenticate(ReadOnlySpan<byte> incomingPacket, out ReadOnlySpan<byte> outgoingPacket);

--- a/RyuSocks/Auth/UsernameAndPassword.cs
+++ b/RyuSocks/Auth/UsernameAndPassword.cs
@@ -41,7 +41,7 @@ namespace RyuSocks.Auth
         {
             if (IsClient)
             {
-                if (incomingPacket == null)
+                if (incomingPacket.IsEmpty)
                 {
                     outgoingPacket = new UsernameAndPasswordRequest(Username, Password).AsSpan();
                     return false;

--- a/RyuSocks/RyuSocks.csproj
+++ b/RyuSocks/RyuSocks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Library</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Version>0.6.0-alpha</Version>
         <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
         <IsAotCompatible>true</IsAotCompatible>

--- a/RyuSocks/RyuSocks.csproj
+++ b/RyuSocks/RyuSocks.csproj
@@ -37,7 +37,7 @@ The full changelog is available at: https://github.com/TSRBerry/RyuSOCKS/blob/ma
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="NetCoreServer" Version="8.0.7" />
+        <PackageReference Include="NetCoreServer" />
     </ItemGroup>
 
     <ItemGroup>

--- a/RyuSocks/SocksClient.cs
+++ b/RyuSocks/SocksClient.cs
@@ -34,7 +34,7 @@ namespace RyuSocks
     {
         // TODO: Keep track of the connection state
 
-        private readonly object _socketLock = new();
+        private readonly Lock _socketLock = new();
         private readonly ProxyEndpoint _proxyEndpoint;
         private Socket _socket;
         private bool _serverEndpointReceived;

--- a/RyuSocks/SocksClient.cs
+++ b/RyuSocks/SocksClient.cs
@@ -256,7 +256,7 @@ namespace RyuSocks
                 {
                     Authenticated = Auth.Authenticate(receivedPacket, out ReadOnlySpan<byte> outgoingPacket);
 
-                    if (outgoingPacket != null)
+                    if (!outgoingPacket.IsEmpty)
                     {
                         sentBytes = Send(outgoingPacket);
                         Debug.Assert(sentBytes == outgoingPacket.Length);

--- a/RyuSocks/SocksClientStream.cs
+++ b/RyuSocks/SocksClientStream.cs
@@ -729,7 +729,7 @@ namespace RyuSocks
             ObjectDisposedException.ThrowIf(_disposed, this);
         }
 
-        private static IOException WrapException(Exception innerException)
+        private static IOException WrapException(SocketException innerException)
         {
             return new IOException(innerException.Message, innerException);
         }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "9.0.100",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
This PR updates all the projects to target .NET 9.0 and adds `Directory.Packages.props` to make managing NuGet packages easier.

We are updating to .NET 9.0 to get support for partial properties, which is pretty exciting for source generators!