### PR TITLE
Add AppendBlock() to AbstractBuilder and move builders to their own namespace

### DIFF
--- a/RyuSocks.Generator/AuthMethodGenerator.cs
+++ b/RyuSocks.Generator/AuthMethodGenerator.cs
@@ -233,6 +233,7 @@ namespace %NAMESPACE%
             sourceExtensions.LeaveScope(";");
             implToEnumBlock.AppendLine("_ => throw new ArgumentException($\"Unknown authentication implementation provided: {authImpl}\", nameof(authImpl)),");
             implToEnumBlock.LeaveScope(";");
+            sourceExtensions.AppendLine();
             sourceExtensions.AppendBlock(implToEnumBlock.GetLines());
             sourceExtensions.LeaveScope();
             sourceExtensions.LeaveScope();

--- a/RyuSocks.Generator/AuthMethodGenerator.cs
+++ b/RyuSocks.Generator/AuthMethodGenerator.cs
@@ -32,6 +32,7 @@ namespace RyuSocks.Generator
         private const string AuthMethodEnumName = "AuthMethod";
         private const string AuthMethodExtensionsClassName = "AuthMethodExtensions";
 
+        #region SourceText
         private const string AttributeText = @"
 using System;
 
@@ -46,8 +47,8 @@ namespace %NAMESPACE%
         /// <summary>
         /// Marks this class as an authentication method. It must have a parameterless constructor and extend <see cref=""%INTERFACE_NAME%""/>.
         /// </summary>
-        /// <param name=""methodId"">The value between 0x00 and 0xFF used to identify this authentication method.</param>
-        public %ATTRIBUTE_NAME%([System.ComponentModel.DataAnnotations.DeniedValues(0xFF)] byte methodId)
+        /// <param name=""methodId"">The value between 0x00 and 0xFE used to identify this authentication method.</param>
+        public %ATTRIBUTE_NAME%([System.ComponentModel.DataAnnotations.Range(0, 0xFE)] byte methodId)
         {
             this.methodId = methodId;
         }
@@ -61,6 +62,7 @@ namespace %NAMESPACE%
     }
 }
 ";
+        #endregion
 
         public void Initialize(IncrementalGeneratorInitializationContext context)
         {

--- a/RyuSocks.Generator/AuthMethodGenerator.cs
+++ b/RyuSocks.Generator/AuthMethodGenerator.cs
@@ -16,6 +16,7 @@
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using RyuSocks.Generator.Builder;
 using System;
 using System.Collections.Immutable;
 using System.Linq;

--- a/RyuSocks.Generator/Builder/AbstractBuilder.cs
+++ b/RyuSocks.Generator/Builder/AbstractBuilder.cs
@@ -1,4 +1,4 @@
-namespace RyuSocks.Generator
+namespace RyuSocks.Generator.Builder
 {
     abstract class AbstractBuilder
     {

--- a/RyuSocks.Generator/Builder/AbstractBuilder.cs
+++ b/RyuSocks.Generator/Builder/AbstractBuilder.cs
@@ -35,6 +35,14 @@ namespace RyuSocks.Generator.Builder
             }
         }
 
+        public void AppendBlock(string[] block)
+        {
+            foreach (var line in block)
+            {
+                AppendLine(line);
+            }
+        }
+
         public abstract void AppendLine();
         public abstract void AppendLine(string text);
     }

--- a/RyuSocks.Generator/Builder/BlockBuilder.cs
+++ b/RyuSocks.Generator/Builder/BlockBuilder.cs
@@ -16,14 +16,6 @@ namespace RyuSocks.Generator.Builder
             _block.Add(GetIndentedString(text));
         }
 
-        public void AppendBlock(string[] block)
-        {
-            foreach (var line in block)
-            {
-                AppendLine(line);
-            }
-        }
-
         public string[] GetLines()
         {
             return [.. _block];

--- a/RyuSocks.Generator/Builder/BlockBuilder.cs
+++ b/RyuSocks.Generator/Builder/BlockBuilder.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 
-namespace RyuSocks.Generator
+namespace RyuSocks.Generator.Builder
 {
     class BlockBuilder : AbstractBuilder
     {

--- a/RyuSocks.Generator/Builder/BlockBuilder.cs
+++ b/RyuSocks.Generator/Builder/BlockBuilder.cs
@@ -16,6 +16,14 @@ namespace RyuSocks.Generator.Builder
             _block.Add(GetIndentedString(text));
         }
 
+        public void AppendBlock(string[] block)
+        {
+            foreach (var line in block)
+            {
+                AppendLine(line);
+            }
+        }
+
         public string[] GetLines()
         {
             return [.. _block];

--- a/RyuSocks.Generator/Builder/CodeBuilder.cs
+++ b/RyuSocks.Generator/Builder/CodeBuilder.cs
@@ -1,6 +1,6 @@
 using System.Text;
 
-namespace RyuSocks.Generator
+namespace RyuSocks.Generator.Builder
 {
     // Original source: https://github.com/Ryujinx/Ryujinx/blob/1df6c07f78c4c3b8c7fc679d7466f79a10c2d496/src/Ryujinx.Horizon.Generators/CodeGenerator.cs
     class CodeBuilder : AbstractBuilder

--- a/RyuSocks.Generator/Builder/CodeBuilder.cs
+++ b/RyuSocks.Generator/Builder/CodeBuilder.cs
@@ -20,8 +20,6 @@ namespace RyuSocks.Generator.Builder
 
         public void AppendBlock(string[] block)
         {
-            AppendLine();
-
             foreach (var line in block)
             {
                 AppendLine(line);

--- a/RyuSocks.Generator/Builder/CodeBuilder.cs
+++ b/RyuSocks.Generator/Builder/CodeBuilder.cs
@@ -18,14 +18,6 @@ namespace RyuSocks.Generator.Builder
             _sb.AppendLine(text);
         }
 
-        public void AppendBlock(string[] block)
-        {
-            foreach (var line in block)
-            {
-                AppendLine(line);
-            }
-        }
-
         public override string ToString()
         {
             return _sb.ToString();

--- a/RyuSocks.Generator/CommandGenerator.cs
+++ b/RyuSocks.Generator/CommandGenerator.cs
@@ -18,6 +18,7 @@ namespace RyuSocks.Generator
         private const string ProxyCommandEnumName = "ProxyCommand";
         private const string ProxyCommandExtensionsClassName = "ProxyCommandExtensions";
 
+        #region SourceText
         private const string AttributeText = @"
 using System;
 
@@ -48,6 +49,7 @@ namespace %NAMESPACE%
     }
 }
 ";
+        #endregion
 
         public void Initialize(IncrementalGeneratorInitializationContext context)
         {

--- a/RyuSocks.Generator/CommandGenerator.cs
+++ b/RyuSocks.Generator/CommandGenerator.cs
@@ -1,5 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using RyuSocks.Generator.Builder;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;


### PR DESCRIPTION
This tiny PR moves the builder classes to their own namespace, moves the `AppendBlock()` method to `AbstractBuilder` and adds regions for the template strings used by the source generators.