### PR TITLE
Remove NetCoreServer dependency

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,6 @@
         <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
         <PackageVersion Include="Moq" Version="4.20.70" />
-        <PackageVersion Include="NetCoreServer" Version="8.0.7" />
         <PackageVersion Include="xunit.v3" Version="1.0.0"/>
         <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0"/>
     </ItemGroup>

--- a/RyuSocks.Test/SocksClientTests.cs
+++ b/RyuSocks.Test/SocksClientTests.cs
@@ -14,14 +14,11 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-using NetCoreServer;
 using RyuSocks.Auth;
 using RyuSocks.Commands;
 using RyuSocks.Utils;
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Threading;
 using Xunit;
@@ -36,7 +33,7 @@ namespace RyuSocks.Test
         public SocksClientTests(SocksServerFixture fixture)
         {
             _fixture = fixture;
-            _client = new SocksClient((IPEndPoint)_fixture.Server.Endpoint)
+            _client = new SocksClient((IPEndPoint)_fixture.Server.LocalEndPoint)
             {
                 OfferedAuthMethods = new Dictionary<AuthMethod, IProxyAuth>
                 {
@@ -55,9 +52,8 @@ namespace RyuSocks.Test
         public void Authenticate_Succeeds()
         {
             _client.Authenticate();
-            Guid sessionId = _fixture.Server.Sessions.Keys.First();
 
-            Assert.Equal(1, _fixture.Server.ConnectedSessions);
+            Assert.Single(_fixture.Server.Sessions);
 
             // FIXME: Race condition here. We are (currently) getting packets asynchronously.
 
@@ -65,7 +61,7 @@ namespace RyuSocks.Test
             const int MaxTries = 10;
             const int SleepSeconds = 1;
             int currentTry = 1;
-            SocksSession session = _fixture.Server.GetSession(sessionId);
+            SocksSession session = _fixture.Server.Sessions[0];
 
             while (currentTry <= MaxTries && !session.Authenticated)
             {
@@ -75,7 +71,7 @@ namespace RyuSocks.Test
 
             // END: Temp workaround
 
-            Assert.True(_fixture.Server.GetSession(sessionId).Authenticated);
+            Assert.True(_fixture.Server.Sessions[0].Authenticated);
         }
     }
 
@@ -115,15 +111,9 @@ namespace RyuSocks.Test
     public class TestSocksServer : SocksServer
     {
         public TestSocksServer(IPAddress address, ushort port = ProxyConsts.DefaultPort) : base(address, port) { }
-        public TestSocksServer(string address, ushort port = ProxyConsts.DefaultPort) : base(address, port) { }
         public TestSocksServer(DnsEndPoint endpoint) : base(endpoint) { }
         public TestSocksServer(IPEndPoint endpoint) : base(endpoint) { }
 
-        public new ConcurrentDictionary<Guid, TcpSession> Sessions => base.Sessions;
-
-        public SocksSession GetSession(Guid id)
-        {
-            return (SocksSession)base.Sessions[id];
-        }
+        public new List<SocksSession> Sessions => base.Sessions;
     }
 }

--- a/RyuSocks/Commands/Server/BindCommand.cs
+++ b/RyuSocks/Commands/Server/BindCommand.cs
@@ -26,14 +26,151 @@ namespace RyuSocks.Commands.Server
     {
         public override bool HandlesCommunication => false;
         public override bool UsesDatagrams => false;
-        private TcpServer _server;
-        private TcpSession _serverSession;
+
+        private readonly Socket _serverSocket;
+        private Socket _serverSession;
+        private SocketAsyncEventArgs _socketAcceptEvent;
+        private SocketAsyncEventArgs _sessionReceiveEvent;
+        private byte[] _sessionReceiveBuffer;
 
         public BindCommand(SocksSession session, IPEndPoint boundEndpoint, ProxyEndpoint source) : base(session, boundEndpoint, source)
         {
-            _server = new TcpServer(this, boundEndpoint, source);
+            _serverSocket = new Socket(boundEndpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 
-            _server.Start();
+            try
+            {
+                _serverSocket.Bind(boundEndpoint);
+            }
+            catch (SocketException e)
+            {
+                Session.SendAsync(new CommandResponse
+                {
+                    Version = ProxyConsts.Version,
+                    ReplyField = e.SocketErrorCode.ToReplyField(),
+                }.AsSpan());
+
+                Session.Disconnect();
+                return;
+            }
+
+            _serverSocket.Listen();
+            AcceptNewSession();
+
+            CommandResponse response = _serverSocket.LocalEndPoint switch
+            {
+                IPEndPoint ipEndPoint => new CommandResponse(ipEndPoint)
+                {
+                    Version = ProxyConsts.Version,
+                    ReplyField = ReplyField.Succeeded,
+                },
+                DnsEndPoint dnsEndPoint => new CommandResponse(dnsEndPoint)
+                {
+                    Version = ProxyConsts.Version,
+                    ReplyField = ReplyField.Succeeded,
+                },
+                _ => throw new InvalidOperationException($"The type of EndPoint is not supported: {_serverSocket.LocalEndPoint}"),
+            };
+
+            Session.SendAsync(response.AsSpan());
+        }
+
+        private void AcceptNewSession()
+        {
+            _socketAcceptEvent?.Dispose();
+            _socketAcceptEvent = new SocketAsyncEventArgs();
+            _socketAcceptEvent.Completed += OnSessionAccepted;
+
+            if (!_serverSocket.AcceptAsync(_socketAcceptEvent))
+            {
+                OnSessionAccepted(this, _socketAcceptEvent);
+            }
+        }
+
+        private void ReceiveFromSession()
+        {
+            if (_serverSession is not { Connected: true })
+            {
+                // TODO: Log error
+                Session.Disconnect();
+                return;
+            }
+
+            _sessionReceiveBuffer ??= new byte[_serverSession.ReceiveBufferSize];
+            _sessionReceiveEvent?.Dispose();
+            _sessionReceiveEvent = new SocketAsyncEventArgs();
+            _sessionReceiveEvent.SetBuffer(_sessionReceiveBuffer);
+            _sessionReceiveEvent.Completed += OnSessionReceived;
+
+            if (!_serverSession.ReceiveAsync(_sessionReceiveEvent))
+            {
+                OnSessionReceived(this, _sessionReceiveEvent);
+            }
+        }
+
+        private void OnSessionAccepted(object sender, SocketAsyncEventArgs e)
+        {
+            if (e.SocketError != SocketError.Success)
+            {
+                // TODO: Log error
+                return;
+            }
+
+            Socket sessionSocket = e.AcceptSocket!;
+
+            if ((!Equals(ProxyEndpoint, ProxyEndpoint.Null) && !ProxyEndpoint.Contains((IPEndPoint)sessionSocket.RemoteEndPoint)) || _serverSession != null)
+            {
+                sessionSocket.Disconnect(false);
+                sessionSocket.Dispose();
+                return;
+            }
+
+            CommandResponse response = sessionSocket.RemoteEndPoint switch
+            {
+                IPEndPoint ipEndPoint => new CommandResponse(ipEndPoint)
+                {
+                    Version = ProxyConsts.Version,
+                    ReplyField = ReplyField.Succeeded,
+                },
+                DnsEndPoint dnsEndPoint => new CommandResponse(dnsEndPoint)
+                {
+                    Version = ProxyConsts.Version,
+                    ReplyField = ReplyField.Succeeded,
+                },
+                _ => throw new InvalidOperationException($"The type of RemoteEndPoint is not supported: {sessionSocket.RemoteEndPoint}"),
+            };
+
+            Session.SendAsync(response.AsSpan());
+            _serverSession = sessionSocket;
+            ReceiveFromSession();
+
+            AcceptNewSession();
+        }
+
+        private void OnSessionReceived(object sender, SocketAsyncEventArgs e)
+        {
+            if (e.SocketError != SocketError.Success)
+            {
+                // TODO: Log error
+                Session.Disconnect();
+                return;
+            }
+
+            if (e.BytesTransferred == 0)
+            {
+                // Connection closed
+                _serverSession.Disconnect(false);
+                _serverSession.Dispose();
+                _serverSession = null;
+                return;
+            }
+
+            // Copy the buffer with the received data - not sure if that's necessary
+            byte[] receivedData = new byte[e.BytesTransferred];
+            _sessionReceiveBuffer.CopyTo(receivedData.AsSpan());
+
+            Session.SendAsync(receivedData);
+
+            ReceiveFromSession();
         }
 
         public override void OnReceived(ReadOnlySpan<byte> buffer)
@@ -43,33 +180,25 @@ namespace RyuSocks.Commands.Server
                 throw new InvalidOperationException("No client connected.");
             }
 
-            if (!_serverSession.IsConnected)
+            if (!_serverSession.Connected)
             {
                 throw new InvalidOperationException("Client disconnected.");
             }
 
-            _serverSession.SendAsync(buffer);
-        }
-
-        private void SendErrorReply(SocketError error)
-        {
-            Session.SendAsync(new CommandResponse
-            {
-                Version = ProxyConsts.Version,
-                ReplyField = error.ToReplyField(),
-            }.AsSpan());
+            _serverSession.SendAsync(buffer.ToArray());
         }
 
         private void Dispose(bool disposing)
         {
             if (disposing)
             {
-                if (_server != null)
-                {
-                    _server.Stop();
-                    _server.Dispose();
-                    _server = null;
-                }
+                _sessionReceiveEvent?.Dispose();
+                _sessionReceiveEvent = null;
+                _socketAcceptEvent?.Dispose();
+                _socketAcceptEvent = null;
+                _serverSession?.Dispose();
+                _serverSession = null;
+                _serverSocket?.Dispose();
             }
         }
 
@@ -77,103 +206,6 @@ namespace RyuSocks.Commands.Server
         {
             Dispose(true);
             GC.SuppressFinalize(this);
-        }
-
-        class TcpServer : NetCoreServer.TcpServer
-        {
-            private readonly BindCommand _command;
-            private readonly ProxyEndpoint _sourceEndpoint;
-
-            public TcpServer(BindCommand command, IPEndPoint endpoint, ProxyEndpoint source) : base(endpoint)
-            {
-                OptionAcceptorBacklog = 1;
-                _command = command;
-                _sourceEndpoint = source;
-            }
-
-            protected override NetCoreServer.TcpSession CreateSession()
-            {
-                return new TcpSession(this, _command);
-            }
-
-            protected override void OnError(SocketError error)
-            {
-                _command.SendErrorReply(error);
-            }
-
-            protected override void OnConnected(NetCoreServer.TcpSession session)
-            {
-                if ((!Equals(_sourceEndpoint, ProxyEndpoint.Null) && !_sourceEndpoint.Contains((IPEndPoint)session.Socket.RemoteEndPoint)) || ConnectedSessions > 1)
-                {
-                    session.Disconnect();
-                    return;
-                }
-
-                CommandResponse response = session.Socket.RemoteEndPoint switch
-                {
-                    IPEndPoint ipEndPoint => new CommandResponse(ipEndPoint)
-                    {
-                        Version = ProxyConsts.Version,
-                        ReplyField = ReplyField.Succeeded,
-                    },
-                    DnsEndPoint dnsEndPoint => new CommandResponse(dnsEndPoint)
-                    {
-                        Version = ProxyConsts.Version,
-                        ReplyField = ReplyField.Succeeded,
-                    },
-                    _ => throw new InvalidOperationException(
-                        $"The type of RemoteEndPoint is not supported: {session.Socket.RemoteEndPoint}"),
-                };
-
-                _command.Session.SendAsync(response.AsSpan());
-                _command._serverSession = (TcpSession)session;
-            }
-
-            protected override void OnStarted()
-            {
-                CommandResponse response = Endpoint switch
-                {
-                    IPEndPoint ipEndPoint => new CommandResponse(ipEndPoint)
-                    {
-                        Version = ProxyConsts.Version,
-                        ReplyField = ReplyField.Succeeded,
-                    },
-                    DnsEndPoint dnsEndPoint => new CommandResponse(dnsEndPoint)
-                    {
-                        Version = ProxyConsts.Version,
-                        ReplyField = ReplyField.Succeeded,
-                    },
-                    _ => throw new InvalidOperationException(
-                        $"The type of EndPoint is not supported: {Endpoint}"),
-                };
-
-                _command.Session.SendAsync(response.AsSpan());
-            }
-        }
-
-        class TcpSession : NetCoreServer.TcpSession
-        {
-            private readonly BindCommand _command;
-
-            public TcpSession(NetCoreServer.TcpServer server, BindCommand command) : base(server)
-            {
-                _command = command;
-            }
-
-            protected override void OnError(SocketError error)
-            {
-                _command.SendErrorReply(error);
-            }
-
-            protected override void OnConnected()
-            {
-                ReceiveAsync();
-            }
-
-            protected override void OnReceived(byte[] buffer, long offset, long size)
-            {
-                _command.Session.SendAsync(buffer.AsSpan((int)offset, (int)size));
-            }
         }
     }
 }

--- a/RyuSocks/Commands/Server/ConnectCommand.cs
+++ b/RyuSocks/Commands/Server/ConnectCommand.cs
@@ -28,33 +28,33 @@ namespace RyuSocks.Commands.Server
     {
         public override bool HandlesCommunication => false;
         public override bool UsesDatagrams => false;
-        private TcpClient _client;
+        private readonly Socket _clientSocket;
+        private SocketAsyncEventArgs _clientReceiveEvent;
+        private byte[] _clientReceiveBuffer;
 
         public ConnectCommand(SocksSession session, IPEndPoint boundEndpoint, ProxyEndpoint destination) : base(session, boundEndpoint, destination)
         {
-            _client = destination.ToEndPoint() switch
-            {
-                IPEndPoint ipDestination => new TcpClient(this, ipDestination),
-                DnsEndPoint dnsDestination => new TcpClient(this, dnsDestination),
-                _ => throw new ArgumentException(
-                    "Invalid EndPoint type provided.", nameof(destination)),
-            };
+            _clientSocket = new Socket(destination.ToEndPoint().AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 
-            if (!_client.Connect())
+            try
+            {
+                _clientSocket.Connect(destination.ToEndPoint());
+            }
+            catch (SocketException e)
             {
                 Session.SendAsync(new CommandResponse
                 {
                     Version = ProxyConsts.Version,
-                    ReplyField = _client.Error.ToReplyField(),
+                    ReplyField = e.SocketErrorCode.ToReplyField(),
                 }.AsSpan());
 
-                _client.ResetError();
-                session.Disconnect();
-
+                Session.Disconnect();
                 return;
             }
 
-            CommandResponse response = _client.Socket.LocalEndPoint switch
+            ReceiveFromServer();
+
+            CommandResponse response = _clientSocket.LocalEndPoint switch
             {
                 IPEndPoint ipEndPoint => new CommandResponse(ipEndPoint)
                 {
@@ -67,32 +67,76 @@ namespace RyuSocks.Commands.Server
                     ReplyField = ReplyField.Succeeded,
                 },
                 _ => throw new InvalidOperationException(
-                    $"The type of LocalEndPoint is not supported: {_client.Socket.LocalEndPoint}"),
+                    $"The type of LocalEndPoint is not supported: {_clientSocket.LocalEndPoint}"),
             };
 
             Session.SendAsync(response.AsSpan());
         }
 
+        private void ReceiveFromServer()
+        {
+            if (_clientSocket is not { Connected: true })
+            {
+                // TODO: Log error
+                Session.Disconnect();
+                return;
+            }
+
+            _clientReceiveBuffer ??= new byte[_clientSocket.ReceiveBufferSize];
+            _clientReceiveEvent?.Dispose();
+            _clientReceiveEvent = new SocketAsyncEventArgs();
+            _clientReceiveEvent.SetBuffer(_clientReceiveBuffer);
+            _clientReceiveEvent.Completed += OnClientReceived;
+
+            if (!_clientSocket.ReceiveAsync(_clientReceiveEvent))
+            {
+                OnClientReceived(this, _clientReceiveEvent);
+            }
+        }
+
+        private void OnClientReceived(object sender, SocketAsyncEventArgs e)
+        {
+            if (e.SocketError != SocketError.Success)
+            {
+                // TODO: Log error
+                Session.Disconnect();
+                return;
+            }
+
+            if (e.BytesTransferred == 0)
+            {
+                // Connection closed
+                _clientSocket.Disconnect(false);
+                Session.Disconnect();
+                return;
+            }
+
+            // Copy the buffer with the received data - not sure if that's necessary
+            byte[] receivedData = new byte[e.BytesTransferred];
+            _clientReceiveBuffer.CopyTo(receivedData.AsSpan());
+
+            Session.SendAsync(receivedData);
+
+            ReceiveFromServer();
+        }
+
         public override void OnReceived(ReadOnlySpan<byte> buffer)
         {
-            if (_client is not { IsConnected: true })
+            if (_clientSocket is not { Connected: true })
             {
                 throw new InvalidOperationException("Client is not connected.");
             }
 
-            _client.SendAsync(buffer);
+            _clientSocket.SendAsync(buffer.ToArray());
         }
 
         private void Dispose(bool disposing)
         {
             if (disposing)
             {
-                if (_client != null)
-                {
-                    _client.Disconnect();
-                    _client.Dispose();
-                    _client = null;
-                }
+                _clientReceiveEvent?.Dispose();
+                _clientReceiveEvent = null;
+                _clientSocket?.Dispose();
             }
         }
 
@@ -100,56 +144,6 @@ namespace RyuSocks.Commands.Server
         {
             Dispose(true);
             GC.SuppressFinalize(this);
-        }
-
-        class TcpClient : NetCoreServer.TcpClient
-        {
-            private readonly ConnectCommand _command;
-
-            public SocketError Error = SocketError.Success;
-
-            public TcpClient(ConnectCommand command, DnsEndPoint endpoint) : base(endpoint)
-            {
-                _command = command;
-            }
-
-            public TcpClient(ConnectCommand command, IPEndPoint endpoint) : base(endpoint)
-            {
-                _command = command;
-            }
-
-            public void ResetError()
-            {
-                Error = SocketError.Success;
-            }
-
-            public override bool Connect()
-            {
-                ResetError();
-                bool result = base.Connect();
-
-                if (!result && Error == SocketError.Success)
-                {
-                    Error = SocketError.ConnectionRefused;
-                }
-
-                return result;
-            }
-
-            protected override void OnError(SocketError error)
-            {
-                Error = error;
-            }
-
-            protected override void OnConnected()
-            {
-                ReceiveAsync();
-            }
-
-            protected override void OnReceived(byte[] buffer, long offset, long size)
-            {
-                _command.Session.SendAsync(buffer.AsSpan((int)offset, (int)size));
-            }
         }
     }
 }

--- a/RyuSocks/Commands/Server/UdpAssociateCommand.cs
+++ b/RyuSocks/Commands/Server/UdpAssociateCommand.cs
@@ -31,10 +31,14 @@ namespace RyuSocks.Commands.Server
         //       This is currently set to the maximum length of an EndpointPacket,
         //       but we usually don't need that much space.
         public override int WrapperLength => 262;
-        private UdpServer _server;
+        private readonly HashSet<ProxyEndpoint> _destinationEndpoints = [];
+        private readonly Socket _socket;
+        private SocketAsyncEventArgs _socketReceiveEvent;
+        private byte[] _socketReceiveBuffer;
+        private IPEndPoint _remoteEndPoint;
 
-        public override int Available { get => _server.Socket.Available; }
-        public override bool Blocking { get => _server.Socket.Blocking; set => _server.Socket.Blocking = value; }
+        public override int Available { get => _socket.Available; }
+        public override bool Blocking { get => _socket.Blocking; set => _socket.Blocking = value; }
 
         public UdpAssociateCommand(SocksSession session, IPEndPoint boundEndpoint, ProxyEndpoint source) : base(session, boundEndpoint, source)
         {
@@ -51,11 +55,118 @@ namespace RyuSocks.Commands.Server
                 return;
             }
 
-            _server = new UdpServer(this, boundEndpoint);
+            _socket = new Socket(boundEndpoint.AddressFamily, SocketType.Dgram, ProtocolType.Udp);
 
-            _server.Start();
+            try
+            {
+                _socket.Bind(boundEndpoint);
+            }
+            catch (SocketException e)
+            {
+                Session.SendAsync(new CommandResponse
+                {
+                    Version = ProxyConsts.Version,
+                    ReplyField = e.SocketErrorCode.ToReplyField(),
+                }.AsSpan());
 
-            // CommandResponse sent by UdpServer.OnStarted() below.
+                session.Disconnect();
+                return;
+            }
+
+            StartReceiveFrom();
+
+            CommandResponse response = _socket.LocalEndPoint switch
+            {
+                IPEndPoint ipEndPoint => new CommandResponse(ipEndPoint)
+                {
+                    Version = ProxyConsts.Version,
+                    ReplyField = ReplyField.Succeeded,
+                },
+                DnsEndPoint dnsEndPoint => new CommandResponse(dnsEndPoint)
+                {
+                    Version = ProxyConsts.Version,
+                    ReplyField = ReplyField.Succeeded,
+                },
+                _ => throw new InvalidOperationException(
+                    $"The type of EndPoint is not supported: {_socket.LocalEndPoint}"),
+            };
+
+            Session.SendAsync(response.AsSpan());
+        }
+
+        private bool IsClientEndpoint(EndPoint endpoint)
+        {
+            return endpoint == ProxyEndpoint.ToEndPoint() ||
+                   (endpoint is IPEndPoint ipEndpoint && ProxyEndpoint.Contains(ipEndpoint));
+        }
+
+        private void StartReceiveFrom()
+        {
+            _socketReceiveBuffer ??= new byte[_socket.ReceiveBufferSize];
+            _socketReceiveEvent?.Dispose();
+            _socketReceiveEvent = new SocketAsyncEventArgs();
+            _socketReceiveEvent.SetBuffer(_socketReceiveBuffer);
+            // TODO: Allow the use of DnsEndPoint
+            _remoteEndPoint = new IPEndPoint(IPAddress.Any, 0);
+            _socketReceiveEvent.RemoteEndPoint = _remoteEndPoint;
+            _socketReceiveEvent.Completed += OnReceivedFrom;
+
+            if (!_socket.ReceiveFromAsync(_socketReceiveEvent))
+            {
+                OnReceivedFrom(this, _socketReceiveEvent);
+            }
+        }
+
+        private void OnReceivedFrom(object sender, SocketAsyncEventArgs e)
+        {
+            if (e.SocketError != SocketError.Success)
+            {
+                // TODO: Log error
+                Session.Disconnect();
+                return;
+            }
+
+            Span<byte> bufferSpan = _socketReceiveBuffer.AsSpan(0, e.BytesTransferred);
+
+            if (IsClientEndpoint(e.RemoteEndPoint))
+            {
+                int bufferLength = bufferSpan.Length;
+                int requiredWrapperSpace = Session.GetRequiredWrapperSpace();
+
+                if (requiredWrapperSpace != 0)
+                {
+                    byte[] wrapperBuffer = new byte[bufferSpan.Length + requiredWrapperSpace];
+                    bufferSpan.CopyTo(wrapperBuffer);
+                    bufferSpan = wrapperBuffer;
+                }
+
+                bufferLength = Session.Unwrap(bufferSpan, bufferLength, out ProxyEndpoint remoteEndpoint);
+
+                if (!_destinationEndpoints.Contains(remoteEndpoint) && !Session.IsDestinationValid(remoteEndpoint))
+                {
+                    return;
+                }
+
+                _destinationEndpoints.Add(remoteEndpoint);
+
+                _socket.SendToAsync(bufferSpan[..bufferLength].ToArray(), remoteEndpoint.ToEndPoint());
+
+                return;
+            }
+
+            ProxyEndpoint proxyEndpoint = e.RemoteEndPoint switch
+            {
+                IPEndPoint ipEndpoint => new ProxyEndpoint(ipEndpoint),
+                DnsEndPoint dnsEndpoint => new ProxyEndpoint(dnsEndpoint),
+                _ => throw new ArgumentException($"The type {e.RemoteEndPoint} is not supported.", nameof(e)),
+            };
+
+            if (!_destinationEndpoints.Contains(proxyEndpoint))
+            {
+                return;
+            }
+
+            Session.SendTo(bufferSpan, proxyEndpoint);
         }
 
         public override int Wrap(Span<byte> buffer, int packetLength, ProxyEndpoint remoteEndpoint)
@@ -84,37 +195,37 @@ namespace RyuSocks.Commands.Server
 
         public override void Shutdown(SocketShutdown how)
         {
-            _server.Socket.Shutdown(how);
+            _socket.Shutdown(how);
         }
 
         public override void GetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, byte[] optionValue)
         {
-            _server.Socket.GetSocketOption(optionLevel, optionName, optionValue);
+            _socket.GetSocketOption(optionLevel, optionName, optionValue);
         }
 
         public override object GetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName)
         {
-            return _server.Socket.GetSocketOption(optionLevel, optionName);
+            return _socket.GetSocketOption(optionLevel, optionName);
         }
 
         public override void SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, byte[] optionValue)
         {
-            _server.Socket.SetSocketOption(optionLevel, optionName, optionValue);
+            _socket.SetSocketOption(optionLevel, optionName, optionValue);
         }
 
         public override void SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, int optionValue)
         {
-            _server.Socket.SetSocketOption(optionLevel, optionName, optionValue);
+            _socket.SetSocketOption(optionLevel, optionName, optionValue);
         }
 
         public override bool Poll(int microSeconds, SelectMode mode)
         {
-            return _server.Socket.Poll(microSeconds, mode);
+            return _socket.Poll(microSeconds, mode);
         }
 
         public override int SendTo(ReadOnlySpan<byte> buffer, SocketFlags socketFlags, EndPoint remoteEP)
         {
-            return _server.Socket.SendTo(buffer, socketFlags, remoteEP);
+            return _socket.SendTo(buffer, socketFlags, remoteEP);
         }
 
         public override void OnReceived(ReadOnlySpan<byte> buffer)
@@ -126,12 +237,7 @@ namespace RyuSocks.Commands.Server
         {
             if (disposing)
             {
-                if (_server != null)
-                {
-                    _server.Stop();
-                    _server.Dispose();
-                    _server = null;
-                }
+                _socket?.Dispose();
             }
         }
 
@@ -139,89 +245,6 @@ namespace RyuSocks.Commands.Server
         {
             Dispose(true);
             GC.SuppressFinalize(this);
-        }
-
-        class UdpServer : NetCoreServer.UdpServer
-        {
-            private readonly UdpAssociateCommand _command;
-            private readonly HashSet<ProxyEndpoint> _destinationEndpoints = [];
-
-            public UdpServer(UdpAssociateCommand command, IPEndPoint endpoint) : base(endpoint)
-            {
-                _command = command;
-            }
-
-            protected override void OnStarted()
-            {
-                CommandResponse response = Endpoint switch
-                {
-                    IPEndPoint ipEndPoint => new CommandResponse(ipEndPoint)
-                    {
-                        Version = ProxyConsts.Version,
-                        ReplyField = ReplyField.Succeeded,
-                    },
-                    DnsEndPoint dnsEndPoint => new CommandResponse(dnsEndPoint)
-                    {
-                        Version = ProxyConsts.Version,
-                        ReplyField = ReplyField.Succeeded,
-                    },
-                    _ => throw new InvalidOperationException(
-                        $"The type of EndPoint is not supported: {Endpoint}"),
-                };
-
-                _command.Session.SendAsync(response.AsSpan());
-            }
-
-            private bool IsClientEndpoint(EndPoint endpoint)
-            {
-                return endpoint == _command.ProxyEndpoint.ToEndPoint() ||
-                       (endpoint is IPEndPoint ipEndpoint && _command.ProxyEndpoint.Contains(ipEndpoint));
-            }
-
-            protected override void OnReceived(EndPoint endpoint, byte[] buffer, long offset, long size)
-            {
-                Span<byte> bufferSpan = buffer.AsSpan((int)offset, (int)size);
-
-                if (IsClientEndpoint(endpoint))
-                {
-                    int bufferLength = bufferSpan.Length;
-                    int requiredWrapperSpace = _command.Session.GetRequiredWrapperSpace();
-
-                    if (requiredWrapperSpace != 0)
-                    {
-                        byte[] wrapperBuffer = new byte[bufferSpan.Length + requiredWrapperSpace];
-                        bufferSpan.CopyTo(wrapperBuffer);
-                        bufferSpan = wrapperBuffer;
-                    }
-
-                    bufferLength = _command.Session.Unwrap(bufferSpan, bufferLength, out ProxyEndpoint remoteEndpoint);
-
-                    if (!_destinationEndpoints.Contains(remoteEndpoint) && !_command.Session.IsDestinationValid(remoteEndpoint))
-                    {
-                        return;
-                    }
-
-                    _destinationEndpoints.Add(remoteEndpoint);
-
-                    this.SendAsync(remoteEndpoint.ToEndPoint(), bufferSpan[..bufferLength]);
-
-                    return;
-                }
-
-                ProxyEndpoint proxyEndpoint = endpoint switch
-                {
-                    IPEndPoint ipEndpoint => new ProxyEndpoint(ipEndpoint),
-                    DnsEndPoint dnsEndpoint => new ProxyEndpoint(dnsEndpoint),
-                    _ => throw new ArgumentException($"The type {endpoint} is not supported.", nameof(endpoint)),
-                };
-
-                if (!_destinationEndpoints.Contains(proxyEndpoint))
-                {
-                    return;
-                }
-
-                _command.Session.SendTo(bufferSpan, proxyEndpoint);
-            }
         }
     }
 }

--- a/RyuSocks/RyuSocks.csproj
+++ b/RyuSocks/RyuSocks.csproj
@@ -37,10 +37,6 @@ The full changelog is available at: https://github.com/TSRBerry/RyuSOCKS/blob/ma
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="NetCoreServer" />
-    </ItemGroup>
-
-    <ItemGroup>
         <ProjectReference Include="..\RyuSocks.Generator\RyuSocks.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 </Project>

--- a/RyuSocks/SocksServer.cs
+++ b/RyuSocks/SocksServer.cs
@@ -14,19 +14,23 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-using NetCoreServer;
 using RyuSocks.Auth;
 using RyuSocks.Commands;
 using RyuSocks.Utils;
 using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Net.Sockets;
 
 namespace RyuSocks
 {
-    public partial class SocksServer : TcpServer
+    public partial class SocksServer : IDisposable
     {
         // TODO: Add (generated) properties for auth methods and commands
+        private readonly Socket _socket;
+        private readonly EndPoint _bindEndpoint;
+        private SocketAsyncEventArgs _socketAcceptEvent;
+        protected readonly List<SocksSession> Sessions = [];
 
         public IReadOnlySet<AuthMethod> AcceptableAuthMethods { get; set; } = new HashSet<AuthMethod>();
         public IReadOnlySet<ProxyCommand> OfferedCommands { get; set; } = new HashSet<ProxyCommand>();
@@ -35,19 +39,74 @@ namespace RyuSocks
         public IReadOnlyDictionary<IPAddress, ushort[]> AllowedDestinations { get; set; } = new Dictionary<IPAddress, ushort[]>();
         public IReadOnlyDictionary<IPAddress, ushort[]> BlockedDestinations { get; set; } = new Dictionary<IPAddress, ushort[]>();
 
-        public SocksServer(IPAddress address, ushort port = ProxyConsts.DefaultPort) : base(address, port) { }
-        public SocksServer(string address, ushort port = ProxyConsts.DefaultPort) : base(address, port) { }
-        public SocksServer(DnsEndPoint endpoint) : base(endpoint) { }
-        public SocksServer(IPEndPoint endpoint) : base(endpoint) { }
+        public EndPoint LocalEndPoint => _socket.LocalEndPoint;
 
-        protected override TcpSession CreateSession()
+        public SocksServer(IPAddress address, ushort port = ProxyConsts.DefaultPort) : this(new IPEndPoint(address, port)) { }
+
+        public SocksServer(DnsEndPoint endpoint)
         {
-            return new SocksSession(this);
+            _socket = new Socket(endpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+            _bindEndpoint = endpoint;
         }
 
-        public override bool Multicast(ReadOnlySpan<byte> buffer)
+        public SocksServer(IPEndPoint endpoint)
         {
-            throw new NotSupportedException();
+            _socket = new Socket(endpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+            _bindEndpoint = endpoint;
+        }
+
+        public void Start()
+        {
+            _socket.Bind(_bindEndpoint);
+            _socket.Listen();
+            AcceptNewSession();
+        }
+
+        private void AcceptNewSession()
+        {
+            _socketAcceptEvent?.Dispose();
+            _socketAcceptEvent = new SocketAsyncEventArgs();
+            _socketAcceptEvent.Completed += OnSessionAccepted;
+
+            if (!_socket.AcceptAsync(_socketAcceptEvent))
+            {
+                OnSessionAccepted(this, _socketAcceptEvent);
+            }
+        }
+
+        private void OnSessionAccepted(object sender, SocketAsyncEventArgs e)
+        {
+            if (e.SocketError != SocketError.Success)
+            {
+                // TODO: Log error
+                return;
+            }
+
+            SocksSession session = new(this, e.AcceptSocket!);
+            Sessions.Add(session);
+
+            AcceptNewSession();
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _socketAcceptEvent?.Dispose();
+                _socketAcceptEvent = null;
+                foreach (var session in Sessions)
+                {
+                    session?.Dispose();
+                }
+                Sessions.Clear();
+                _socket?.Dispose();
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/RyuSocks/SocksSession.cs
+++ b/RyuSocks/SocksSession.cs
@@ -14,7 +14,6 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-using NetCoreServer;
 using RyuSocks.Auth;
 using RyuSocks.Auth.Extensions;
 using RyuSocks.Commands;
@@ -30,156 +29,58 @@ using System.Security.Authentication;
 
 namespace RyuSocks
 {
-    public partial class SocksSession : TcpSession
+    public partial class SocksSession : IDisposable
     {
+        private readonly SocksServer _server;
+        private readonly Socket _socket;
+        private SocketAsyncEventArgs _socketReceiveEvent;
+        private byte[] _socketReceiveBuffer;
+
         public bool Closing { get; protected set; }
         public bool Authenticated { get; protected set; }
         public IProxyAuth Auth { get; protected set; }
         public ServerCommand Command { get; protected set; }
 
-        public new SocksServer Server => base.Server as SocksServer;
-
-        public SocksSession(TcpServer server) : base(server) { }
-
-        public bool IsDestinationValid(ProxyEndpoint destination)
+        public SocksSession(SocksServer server, Socket socket)
         {
-            if (!Server.UseAllowList && !Server.UseBlockList)
-            {
-                return true;
-            }
+            _server = server;
+            _socket = socket;
 
-            bool isDestinationValid = false;
-
-            // Check whether the client is allowed to connect to the requested destination.
-            foreach (IPAddress destinationAddress in destination.Addresses)
-            {
-                if (Server.UseAllowList
-                    && Server.AllowedDestinations.TryGetValue(destinationAddress, out ushort[] allowedPorts)
-                    && allowedPorts.Contains(destination.Port))
-                {
-                    isDestinationValid = true;
-                    break;
-                }
-
-                if (Server.UseBlockList
-                    && (!Server.BlockedDestinations.TryGetValue(destinationAddress, out allowedPorts)
-                        || !allowedPorts.Contains(destination.Port)))
-                {
-                    isDestinationValid = true;
-                    break;
-                }
-            }
-
-            return isDestinationValid;
+            StartReceive();
         }
 
-        public int GetRequiredWrapperSpace()
+        private void StartReceive()
         {
-            int wrapperSpace = 0;
-
-            if (Authenticated)
+            if (_socket is not { Connected: true } || Closing)
             {
-                wrapperSpace = Auth.WrapperLength;
-            }
-
-            if (Command != null && wrapperSpace < Command.WrapperLength)
-            {
-                wrapperSpace = Command.WrapperLength;
-            }
-
-            return wrapperSpace;
-        }
-
-        // TODO: Remove this once async Send/Receive for commands has been implemented.
-        public int Unwrap(Span<byte> packet, int packetLength, out ProxyEndpoint remoteEndpoint)
-        {
-            if (!IsConnected || Closing)
-            {
-                throw new InvalidOperationException("Session is not connected or closing soon.");
-            }
-
-            remoteEndpoint = null;
-            int totalWrapperLength = packetLength;
-
-            if (Authenticated)
-            {
-                totalWrapperLength = Auth.Unwrap(packet, packetLength, out remoteEndpoint);
-            }
-
-            if (Command != null)
-            {
-                totalWrapperLength = Command.Unwrap(packet, packetLength, out remoteEndpoint);
-            }
-
-            return totalWrapperLength;
-        }
-
-        protected virtual void ProcessAuthMethodSelection(ReadOnlySpan<byte> buffer)
-        {
-            var request = new MethodSelectionRequest(buffer.ToArray());
-            request.Validate();
-
-            foreach (var requestedAuthMethod in request.Methods)
-            {
-                if (Server.AcceptableAuthMethods.Contains(requestedAuthMethod))
-                {
-                    var reply = new MethodSelectionResponse(requestedAuthMethod)
-                    {
-                        Version = ProxyConsts.Version,
-                    };
-
-                    SendAsync(reply.AsSpan());
-                    Auth = requestedAuthMethod.GetAuth();
-
-                    return;
-                }
-            }
-
-            var errorReply = new MethodSelectionResponse(AuthMethod.NoAcceptableMethods)
-            {
-                Version = ProxyConsts.Version,
-            };
-
-            SendAsync(errorReply.AsSpan());
-            Closing = true;
-        }
-
-        protected virtual void ProcessCommandRequest(Span<byte> buffer, int bufferLength)
-        {
-            bufferLength = Unwrap(buffer, bufferLength, out _);
-            var request = new CommandRequest(buffer[..bufferLength].ToArray());
-            request.Validate();
-
-            var errorReply = new CommandResponse(new IPEndPoint(0, 0))
-            {
-                Version = ProxyConsts.Version,
-            };
-
-            // Check whether the client requested a valid command.
-            if (Server.OfferedCommands.Contains(request.Command))
-            {
-                // FIXME: Some commands use this field as the client endpoint, not the destination.
-                if (IsDestinationValid(request.ProxyEndpoint))
-                {
-                    Command = request.Command.GetServerCommand()(this, (IPEndPoint)Server.Endpoint, request.ProxyEndpoint);
-                    return;
-                }
-
-                errorReply.ReplyField = ReplyField.ConnectionNotAllowed;
-                SendAsync(errorReply.AsSpan());
+                // TODO: Log error
                 Closing = true;
-
                 return;
             }
 
-            errorReply.ReplyField = ReplyField.CommandNotSupported;
-            SendAsync(errorReply.AsSpan());
-            Closing = true;
+            _socketReceiveBuffer ??= new byte[_socket.ReceiveBufferSize];
+            _socketReceiveEvent?.Dispose();
+            _socketReceiveEvent = new SocketAsyncEventArgs();
+            _socketReceiveEvent.SetBuffer(_socketReceiveBuffer);
+            _socketReceiveEvent.Completed += OnReceived;
+
+            if (!_socket.ReceiveAsync(_socketReceiveEvent))
+            {
+                OnReceived(this, _socketReceiveEvent);
+            }
         }
 
-        protected override void OnReceived(byte[] buffer, long offset, long size)
+        protected virtual void OnReceived(object sender, SocketAsyncEventArgs e)
         {
-            Span<byte> bufferSpan = buffer.AsSpan((int)offset, (int)size);
+            if (e.SocketError != SocketError.Success || e.BytesTransferred == 0)
+            {
+                // TODO: Log error
+                _socket.Disconnect(false);
+                Closing = true;
+                return;
+            }
+
+            Span<byte> bufferSpan = _socketReceiveBuffer.AsSpan(0, e.BytesTransferred);
 
             // Choose the authentication method.
             if (Auth == null)
@@ -232,19 +133,153 @@ namespace RyuSocks
             }
 
             bufferLength = Unwrap(bufferSpan, bufferLength, out _);
-
             Command.OnReceived(bufferSpan[..bufferLength]);
+
+            StartReceive();
         }
 
-        protected override void OnEmpty()
+        public bool IsDestinationValid(ProxyEndpoint destination)
         {
-            if (Closing)
+            if (!_server.UseAllowList && !_server.UseBlockList)
             {
-                Disconnect();
+                return true;
             }
+
+            bool isDestinationValid = false;
+
+            // Check whether the client is allowed to connect to the requested destination.
+            foreach (IPAddress destinationAddress in destination.Addresses)
+            {
+                if (_server.UseAllowList
+                    && _server.AllowedDestinations.TryGetValue(destinationAddress, out ushort[] allowedPorts)
+                    && allowedPorts.Contains(destination.Port))
+                {
+                    isDestinationValid = true;
+                    break;
+                }
+
+                if (_server.UseBlockList
+                    && (!_server.BlockedDestinations.TryGetValue(destinationAddress, out allowedPorts)
+                        || !allowedPorts.Contains(destination.Port)))
+                {
+                    isDestinationValid = true;
+                    break;
+                }
+            }
+
+            return isDestinationValid;
         }
 
-        public override bool SendAsync(ReadOnlySpan<byte> buffer)
+        public int GetRequiredWrapperSpace()
+        {
+            int wrapperSpace = 0;
+
+            if (Authenticated)
+            {
+                wrapperSpace = Auth.WrapperLength;
+            }
+
+            if (Command != null && wrapperSpace < Command.WrapperLength)
+            {
+                wrapperSpace = Command.WrapperLength;
+            }
+
+            return wrapperSpace;
+        }
+
+        // TODO: Remove this once async Send/Receive for commands has been implemented.
+        public int Unwrap(Span<byte> packet, int packetLength, out ProxyEndpoint remoteEndpoint)
+        {
+            if (!_socket.Connected || Closing)
+            {
+                throw new InvalidOperationException("Session is not connected or closing soon.");
+            }
+
+            remoteEndpoint = null;
+            int totalWrapperLength = packetLength;
+
+            if (Authenticated)
+            {
+                totalWrapperLength = Auth.Unwrap(packet, packetLength, out remoteEndpoint);
+            }
+
+            if (Command != null)
+            {
+                totalWrapperLength = Command.Unwrap(packet, packetLength, out remoteEndpoint);
+            }
+
+            return totalWrapperLength;
+        }
+
+        protected virtual void ProcessAuthMethodSelection(ReadOnlySpan<byte> buffer)
+        {
+            var request = new MethodSelectionRequest(buffer.ToArray());
+            request.Validate();
+
+            foreach (var requestedAuthMethod in request.Methods)
+            {
+                if (_server.AcceptableAuthMethods.Contains(requestedAuthMethod))
+                {
+                    var reply = new MethodSelectionResponse(requestedAuthMethod)
+                    {
+                        Version = ProxyConsts.Version,
+                    };
+
+                    SendAsync(reply.AsSpan());
+                    Auth = requestedAuthMethod.GetAuth();
+
+                    return;
+                }
+            }
+
+            var errorReply = new MethodSelectionResponse(AuthMethod.NoAcceptableMethods)
+            {
+                Version = ProxyConsts.Version,
+            };
+
+            SendAsync(errorReply.AsSpan());
+            Closing = true;
+        }
+
+        protected virtual void ProcessCommandRequest(Span<byte> buffer, int bufferLength)
+        {
+            bufferLength = Unwrap(buffer, bufferLength, out _);
+            var request = new CommandRequest(buffer[..bufferLength].ToArray());
+            request.Validate();
+
+            var errorReply = new CommandResponse(new IPEndPoint(0, 0))
+            {
+                Version = ProxyConsts.Version,
+            };
+
+            // Check whether the client requested a valid command.
+            if (_server.OfferedCommands.Contains(request.Command))
+            {
+                // FIXME: Some commands use this field as the client endpoint, not the destination.
+                if (IsDestinationValid(request.ProxyEndpoint))
+                {
+                    Command = request.Command.GetServerCommand()(this, (IPEndPoint)_server.LocalEndPoint, request.ProxyEndpoint);
+                    return;
+                }
+
+                errorReply.ReplyField = ReplyField.ConnectionNotAllowed;
+                SendAsync(errorReply.AsSpan());
+                Closing = true;
+
+                return;
+            }
+
+            errorReply.ReplyField = ReplyField.CommandNotSupported;
+            SendAsync(errorReply.AsSpan());
+            Closing = true;
+        }
+
+        public void Disconnect()
+        {
+            _socket.Disconnect(false);
+        }
+
+        public void SendAsync(ReadOnlySpan<byte> buffer)
         {
             int bufferLength = buffer.Length;
             int bufferSize = bufferLength + GetRequiredWrapperSpace();
@@ -278,10 +313,10 @@ namespace RyuSocks
                 throw new NotImplementedException("Async Send/Receive for commands has not been implemented yet.");
             }
 
-            return base.SendAsync(sendBuffer[..bufferLength]);
+            _socket.SendAsync(sendBuffer[..bufferLength].ToArray());
         }
 
-        public override long Send(ReadOnlySpan<byte> buffer)
+        public int Send(ReadOnlySpan<byte> buffer)
         {
             int bufferLength = buffer.Length;
             int bufferSize = bufferLength + GetRequiredWrapperSpace();
@@ -312,7 +347,7 @@ namespace RyuSocks
 
             if (Command is { HandlesCommunication: true })
             {
-                long sentSize = Command.Send(sendBuffer[..bufferLength], SocketFlags.None, out SocketError errorCode);
+                int sentSize = Command.Send(sendBuffer[..bufferLength], SocketFlags.None, out SocketError errorCode);
 
                 if (errorCode != SocketError.Success)
                 {
@@ -322,7 +357,7 @@ namespace RyuSocks
                 return sentSize;
             }
 
-            return base.Send(sendBuffer[..bufferLength]);
+            return _socket.Send(sendBuffer[..bufferLength]);
         }
 
         public int SendTo(ReadOnlySpan<byte> buffer, ProxyEndpoint endpoint)
@@ -369,6 +404,23 @@ namespace RyuSocks
             };
 
             return SendTo(buffer, remoteEndpoint);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                Closing = true;
+                _socketReceiveEvent?.Dispose();
+                _socketReceiveBuffer = null;
+                _socket?.Dispose();
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
     }
 }


### PR DESCRIPTION
This PR removes the dependency on `NetCoreServer` and instead we are working with sockets directly now.

The current state just allows the project to compile and the tests to pass, but there is more work to be done before it can be merged.